### PR TITLE
Add NAMESPACE_NFS to env definition

### DIFF
--- a/templates/nfs-autoprovisioner/env.j2
+++ b/templates/nfs-autoprovisioner/env.j2
@@ -1,2 +1,3 @@
 NFS_SERVER={{ ocp_cluster_net_gw }}
 NFS_PATH="{{ nfs_export_path }}/dynamic"
+NAMESPACE_NFS="nfs-autoprovisioner"


### PR DESCRIPTION
Hey gang - great provisioner here.  I just utilized this to deploy NFS StorageClass & backing for the container registry and outside of a hiccup, it worked very well.

Issue I had was that the `/files/post-install-scripts/nfs-autoprovisioner/template.yaml` kept failing when used with the corresponding `env` file from `/templates/nfs-autoprovisioner/` due to `NAMESPACE_NFS` not being defined.

I believe this is because the default value of the parameter is defined but also set as required in the template.yaml.

Defining the `NAMESPACE_NFS` parameter in the env file helped fix the issue!

Hope this helps, if it doesn't make sense to include feel free to close/ignore.