### PR TITLE
Stop checking 'master' out, checkout the matching commit.

### DIFF
--- a/tasks/kvm_deploy.yml
+++ b/tasks/kvm_deploy.yml
@@ -1,4 +1,6 @@
 ---
+################
+#
 - name: Create Initial required directory as {{ kvm_workdir }}
   when: kvm_install == "true" or kvm_install == "minimal"
   tags: install
@@ -61,6 +63,8 @@
         /sbin/semanage fcontext -a -t virt_var_lib_t "{{ kvm_pool_location }}(/.*)?"
         /sbin/restorecon -rv {{ kvm_pool_location }}
 
+################
+#
 - name: Install KVM
   when: kvm_install == "true"
   become: true
@@ -96,7 +100,6 @@
         enabled: yes
       when: kvm_firewall == "firewalld"
 
-
     # Update qemu to +2.4 because option fw_cfg added in 2.4
     #  "qemu-kvm: -fw_cfg: invalid option"
     #  https://github.com/qemu/qemu/commit/81b2b81062612e
@@ -123,7 +126,6 @@
       yum:
         name: '*'
         state: latest
-
 
     - name: Enable and Start network
       become: true
@@ -156,7 +158,6 @@
       register: result
       failed_when: "result.rc != 0"
 
-
     - name: Install Load Balancer
       when: lb == "true"
       become: true
@@ -173,7 +174,6 @@
             src: haproxy.cfg.j2
             dest: /etc/haproxy/haproxy.cfg
 
-
         - name: SEBool allow haproxy connect any port
           ignore_errors: yes
           shell: "setsebool -P haproxy_connect_any 1"
@@ -186,6 +186,8 @@
           with_items:
             - haproxy
 
+################
+#
 - name: Install NFS requirements
   when: nfs_storage == "true"
   become: true
@@ -244,6 +246,8 @@
         enabled: True
 
 
+################
+#
 - name: Prepare KVM
   when: kvm_configure == "true"
   become: true
@@ -309,7 +313,6 @@
         iptables-save > /etc/iptables.conf
       when: kvm_firewall == "iptables"
 
-
     - name: Configure Firewalld
       become: true
       ignore_errors: yes
@@ -328,7 +331,6 @@
         firewall-cmd --zone=libvirt --add-rich-rule "rule family="ipv4" source address=0.0.0.0/0 accept"  --permanent
         firewall-cmd --reload
       when: kvm_firewall == "firewalld"
-
 
     - name: Create a directory /etc/NetworkManager/conf.d if it does not exist
       file:

--- a/tasks/kvm_deploy.yml
+++ b/tasks/kvm_deploy.yml
@@ -193,11 +193,10 @@
   block:
     - name: Install needed packages for NFS
       yum:
+        name: 
+          - nfs-utils
+          - rpcbind
         state: latest
-        name: "{{ item }}"
-      with_items:
-        - nfs-utils
-        - rpcbind
 
     - name: Set user and group for NFS nobody ( Fedora/Centos/RHEL 8 )
       set_fact:

--- a/tasks/kvm_publish.yml
+++ b/tasks/kvm_publish.yml
@@ -1,118 +1,116 @@
 ---
+################
+#
+  - name: Configure Iptables
+    become: true
+    tags: install
+    ignore_errors: yes
+    shell: |
+      IFACE=$(nmcli con show "{{ kvm_interface }}" | grep connection.interface-name | awk '{print $2}')
+      # Publishing
+      if [ {{ compute.0.replicas }} -ne 0 ]
+      then
+        API_VIP={{ ocp_api_vip }}
+        APPS_VIP={{ ocp_apps_vip }}
+      else
+        API_VIP={{ ocp_api_vip }}
+        APPS_VIP={{ ocp_api_vip }}
+      fi
+      if [ {{ lb }} == "true" ]
+      then
+        API_VIP={{ ocp_cluster_net_gw }}
+        APPS_VIP={{ ocp_cluster_net_gw }}
+      fi
+      iptables -I FORWARD 1 -i any -o any -j ACCEPT
+      iptables -I PREROUTING 1 -t nat -i $IFACE -p tcp --dport 6443 -j DNAT --to $API_VIP:6443
+      iptables -I FORWARD 1 -p tcp -d $API_VIP --dport 6443 -j ACCEPT
+      iptables -I PREROUTING 1 -t nat -i $IFACE -p tcp --dport 443 -j DNAT --to $APPS_VIP:443
+      iptables -I FORWARD 1 -p tcp -d $APPS_VIP --dport 443 -j ACCEPT
+      iptables -I PREROUTING 1  -t nat -i $IFACE -p tcp --dport 80 -j DNAT --to $APPS_VIP:80
+      iptables -I FORWARD 1 -p tcp -d $APPS_VIP --dport 80 -j ACCEPT
+      iptables -I INPUT 1 -p tcp  --dport 6443 -j ACCEPT
+      iptables -I INPUT 1 -p tcp  --dport 443 -j ACCEPT
+      iptables -I INPUT 1 -p tcp  --dport 80 -j ACCEPT
+      iptables-save > /etc/iptables.conf
+    when: kvm_firewall == "iptables"
 
-    - name: Configure Iptables
-      become: true
-      tags: install
-      ignore_errors: yes
-      shell: |
-        IFACE=$(nmcli con show "{{ kvm_interface }}" | grep connection.interface-name | awk '{print $2}')
-        # Publishing
-        if [ {{ compute.0.replicas }} -ne 0 ]
-        then
-          API_VIP={{ ocp_api_vip }}
-          APPS_VIP={{ ocp_apps_vip }}
-        else
-          API_VIP={{ ocp_api_vip }}
-          APPS_VIP={{ ocp_api_vip }}
-        fi
-        if [ {{ lb }} == "true" ]
-        then
-          API_VIP={{ ocp_cluster_net_gw }}
-          APPS_VIP={{ ocp_cluster_net_gw }}
-        fi
-        iptables -I FORWARD 1 -i any -o any -j ACCEPT
-        iptables -I PREROUTING 1 -t nat -i $IFACE -p tcp --dport 6443 -j DNAT --to $API_VIP:6443
-        iptables -I FORWARD 1 -p tcp -d $API_VIP --dport 6443 -j ACCEPT
-        iptables -I PREROUTING 1 -t nat -i $IFACE -p tcp --dport 443 -j DNAT --to $APPS_VIP:443
-        iptables -I FORWARD 1 -p tcp -d $APPS_VIP --dport 443 -j ACCEPT
-        iptables -I PREROUTING 1  -t nat -i $IFACE -p tcp --dport 80 -j DNAT --to $APPS_VIP:80
-        iptables -I FORWARD 1 -p tcp -d $APPS_VIP --dport 80 -j ACCEPT
-        iptables -I INPUT 1 -p tcp  --dport 6443 -j ACCEPT
-        iptables -I INPUT 1 -p tcp  --dport 443 -j ACCEPT
-        iptables -I INPUT 1 -p tcp  --dport 80 -j ACCEPT
-        iptables-save > /etc/iptables.conf
-      when: kvm_firewall == "iptables"
+  - name: Configure Firewalld
+    become: true
+    tags: install
+    ignore_errors: yes
+    shell: |
+      IFACE=$(nmcli con show "{{ kvm_interface }}" | grep connection.interface-name | awk '{print $2}')
+      ZONE_EXT=$(firewall-cmd --list-all-zones | grep -B 3 $IFACE | head -n 1 | awk '{print $1}')
+      # Publishing
+      if [ {{ compute.0.replicas }} -ne 0 ]
+      then
+        API_VIP={{ ocp_api_vip }}
+        APPS_VIP={{ ocp_apps_vip }}
+      else
+        API_VIP={{ ocp_api_vip }}
+        APPS_VIP={{ ocp_api_vip }}
+      fi
+      if [ {{ lb }} == "true" ]
+      then
+        API_VIP={{ ocp_cluster_net_gw }}
+        APPS_VIP={{ ocp_cluster_net_gw }}
+      fi
+      firewall-cmd --zone=$ZONE_EXT --add-service=http --permanent
+      firewall-cmd --zone=$ZONE_EXT --add-service=https --permanent
+      firewall-cmd --zone=$ZONE_EXT --add-service=ocpapi --permanent
+      firewall-cmd --permanent --add-forward-port=port=6443:proto=tcp:toport=6443:toaddr=$API_VIP --zone=$ZONE_EXT
+      firewall-cmd --permanent --add-forward-port=port=443:proto=tcp:toport=443:toaddr=$APPS_VIP --zone=$ZONE_EXT
+      firewall-cmd --permanent --add-forward-port=port=80:proto=tcp:toport=80:toaddr=$APPS_VIP --zone=$ZONE_EXT
+      firewall-cmd --reload
+    when: kvm_firewall == "firewalld"
 
+  - name: Access information
+    become: true
+    tags: install
+    ignore_errors: yes
+    block:
+      - name: Get Web Console URL
+        shell: "oc get route -n openshift-console | grep https | awk '{print $2}' "
+        register: webconsoleurl
 
-    - name: Configure Firewalld
-      become: true
-      tags: install
-      ignore_errors: yes
-      shell: |
-        IFACE=$(nmcli con show "{{ kvm_interface }}" | grep connection.interface-name | awk '{print $2}')
-        ZONE_EXT=$(firewall-cmd --list-all-zones | grep -B 3 $IFACE | head -n 1 | awk '{print $1}')
-        # Publishing
-        if [ {{ compute.0.replicas }} -ne 0 ]
-        then
-          API_VIP={{ ocp_api_vip }}
-          APPS_VIP={{ ocp_apps_vip }}
-        else
-          API_VIP={{ ocp_api_vip }}
-          APPS_VIP={{ ocp_api_vip }}
-        fi
-        if [ {{ lb }} == "true" ]
-        then
-          API_VIP={{ ocp_cluster_net_gw }}
-          APPS_VIP={{ ocp_cluster_net_gw }}
-        fi
-        firewall-cmd --zone=$ZONE_EXT --add-service=http --permanent
-        firewall-cmd --zone=$ZONE_EXT --add-service=https --permanent
-        firewall-cmd --zone=$ZONE_EXT --add-service=ocpapi --permanent
-        firewall-cmd --permanent --add-forward-port=port=6443:proto=tcp:toport=6443:toaddr=$API_VIP --zone=$ZONE_EXT
-        firewall-cmd --permanent --add-forward-port=port=443:proto=tcp:toport=443:toaddr=$APPS_VIP --zone=$ZONE_EXT
-        firewall-cmd --permanent --add-forward-port=port=80:proto=tcp:toport=80:toaddr=$APPS_VIP --zone=$ZONE_EXT
-        firewall-cmd --reload
-      when: kvm_firewall == "firewalld"
+      - name: Get kubeadmin password
+        shell: "tail {{ ocp_install_path }}/install/.openshift_install.log | grep password: | awk -F 'password: ' '{print  substr($2, 1, length($2)-1)}'"
+        register: kubeadminpass
 
+      - name: OpenShift Web Console access
+        debug:
+          msg:
+            - "                                                                                                        "
+            - "                                                                                                        "
+            - "   ***********************************************************************************************      "
+            - "                                         WEB CONSOLE ACCESS                                             "
+            - "   ***********************************************************************************************      "
+            - "                                                                                                        "
+            - "   https://{{ webconsoleurl.stdout }}      "
+            - "                                                                                                        "
+            - "                                                                                                        "
+            - "   Username: kubeadmin     Password: {{ kubeadminpass.stdout  }}                                            "
+            - "                                                                                                        "
+            - "   ***********************************************************************************************      "
+        when: ocp_create_users  != "true"
 
-
-    - name: Access information
-      become: true
-      tags: install
-      ignore_errors: yes
-      block:
-        - name: Get Web Console URL
-          shell: "oc get route -n openshift-console | grep https | awk '{print $2}' "
-          register: webconsoleurl
-
-        - name: Get kubeadmin password
-          shell: "tail {{ ocp_install_path }}/install/.openshift_install.log | grep password: | awk -F 'password: ' '{print  substr($2, 1, length($2)-1)}'"
-          register: kubeadminpass
-
-        - name: OpenShift Web Console access
-          debug:
-            msg:
-              - "                                                                                                        "
-              - "                                                                                                        "
-              - "   ***********************************************************************************************      "
-              - "                                         WEB CONSOLE ACCESS                                             "
-              - "   ***********************************************************************************************      "
-              - "                                                                                                        "
-              - "   https://{{ webconsoleurl.stdout }}      "
-              - "                                                                                                        "
-              - "                                                                                                        "
-              - "   Username: kubeadmin     Password: {{ kubeadminpass.stdout  }}                                            "
-              - "                                                                                                        "
-              - "   ***********************************************************************************************      "
-          when: ocp_create_users  != "true"
-
-        - name: OpenShift Web Console access
-          debug:
-            msg:
-              - "                                                                                                        "
-              - "                                                                                                        "
-              - "   ***********************************************************************************************      "
-              - "                                         WEB CONSOLE ACCESS                                             "
-              - "   ***********************************************************************************************      "
-              - "                                                                                                        "
-              - "   https://{{ webconsoleurl.stdout }}     "
-              - "                                                                                                        "
-              - "                                                                                                        "
-              - "   htpasswd_provider - Cluster Admin         Username: clusteradmin  Password: {{ ocp_clusteradmin_password }} "
-              - "   htpasswd_provider - Cluster Readonly      Username: viewuser      Password: {{ ocp_users_password }} "
-              - "   htpasswd_provider - Regular User (1-25)   Username: userXX        Password: {{ ocp_users_password }} "
-              - "   kube:admin        - system:admin          Username: kubeadmin     Password: {{ kubeadminpass.stdout  }}  "
-              - "                                                                                                        "
-              - "   ***********************************************************************************************      "
-          when: ocp_create_users  == "true"
-      when: kvm_publish == "true"
+      - name: OpenShift Web Console access
+        debug:
+          msg:
+            - "                                                                                                        "
+            - "                                                                                                        "
+            - "   ***********************************************************************************************      "
+            - "                                         WEB CONSOLE ACCESS                                             "
+            - "   ***********************************************************************************************      "
+            - "                                                                                                        "
+            - "   https://{{ webconsoleurl.stdout }}     "
+            - "                                                                                                        "
+            - "                                                                                                        "
+            - "   htpasswd_provider - Cluster Admin         Username: clusteradmin  Password: {{ ocp_clusteradmin_password }} "
+            - "   htpasswd_provider - Cluster Readonly      Username: viewuser      Password: {{ ocp_users_password }} "
+            - "   htpasswd_provider - Regular User (1-25)   Username: userXX        Password: {{ ocp_users_password }} "
+            - "   kube:admin        - system:admin          Username: kubeadmin     Password: {{ kubeadminpass.stdout  }}  "
+            - "                                                                                                        "
+            - "   ***********************************************************************************************      "
+        when: ocp_create_users  == "true"
+    when: kvm_publish == "true"

--- a/tasks/ocp_deploy.yml
+++ b/tasks/ocp_deploy.yml
@@ -38,18 +38,6 @@
         curl --compressed -J -L -o {{ ocp_install_path }}/artifacts/openshift-client-{{ ocp_release }}/openshift-client-linux-{{ ocp_release }}.tar.gz  {{ ocp_mirror }}/{{ ocp_release }}/openshift-client-linux-{{ ocp_release }}.tar.gz
         tar -C {{ ocp_install_path }}/artifacts/openshift-client-{{ ocp_release }}/  -xvf  {{ ocp_install_path }}/artifacts/openshift-client-{{ ocp_release }}/openshift-client-linux-{{ ocp_release }}.tar.gz
 
-    - name: Create /usr/local/bin/oc and /usr/local/bin/openshift-install symbolic links
-      ignore_errors: yes
-      become: yes
-      file:
-        src: "{{ item.value }}"
-        dest: "{{ item.key }}"
-        state: link
-        force: yes
-      with_dict:
-        "/usr/local/bin/oc": "{{ ocp_install_path }}/artifacts/openshift-client-{{ ocp_release }}/oc"
-        "/usr/local/bin/openshift-install": "{{ ocp_install_path }}/artifacts/openshift-installer-{{ ocp_release }}/openshift-install"
-
     - name: Clone Openshift installer repo
       git:
         repo: "{{ ocp_openshift_installer_repo }}"
@@ -61,14 +49,14 @@
     ## NOTE : In order to reliably manage deployment we must use a matching repo for the release to be installed
     - name: Find git commit ID for OCP release
       shell: |
-        /usr/local/bin/oc adm release info {{ ocp_release }} --commit-urls \
+        {{ ocp_install_path }}/artifacts/openshift-client-{{ ocp_release }}/oc adm release info {{ ocp_release }} --commit-urls \
           |awk '{ if ( $1 == "installer" ) { n=split($2,a,"/"); print a[n]} }'
       register:
         installercommitid
 
     - name: Checkout specific GIT commit ID for release {{ installercommitid.stdout }}
-      shell: >
-        git checkout {{ installercommitid.stdout }}
+      shell: |
+        git checkout -b release-{{ ocp_release }} {{ installercommitid.stdout }}
       args:
         chdir:
           "{{ kvm_workdir }}/go/src/github.com/openshift/installer"

--- a/tasks/ocp_deploy.yml
+++ b/tasks/ocp_deploy.yml
@@ -56,7 +56,8 @@
 
     - name: Checkout specific GIT commit ID for release {{ installercommitid.stdout }}
       shell: |
-        git checkout -b release-{{ ocp_release }} {{ installercommitid.stdout }} || /bin/true
+        git branch -d release-{{ ocp_release }} || /bin/true
+        git checkout -b release-{{ ocp_release }} {{ installercommitid.stdout }}
       args:
         chdir:
           "{{ kvm_workdir }}/go/src/github.com/openshift/installer"

--- a/tasks/ocp_deploy.yml
+++ b/tasks/ocp_deploy.yml
@@ -24,6 +24,32 @@
           - git
         state: present
 
+    - name: Create OpenShift artifacts directories
+      file:
+        path: "{{ ocp_install_path }}/artifacts/openshift-{{ item }}-{{ ocp_release }}"
+        state: directory
+        mode: u+rwX,g-w,o-w
+      with_items:
+        - installer
+        - client
+
+    - name: Download Openshift client
+      shell: |
+        curl --compressed -J -L -o {{ ocp_install_path }}/artifacts/openshift-client-{{ ocp_release }}/openshift-client-linux-{{ ocp_release }}.tar.gz  {{ ocp_mirror }}/{{ ocp_release }}/openshift-client-linux-{{ ocp_release }}.tar.gz
+        tar -C {{ ocp_install_path }}/artifacts/openshift-client-{{ ocp_release }}/  -xvf  {{ ocp_install_path }}/artifacts/openshift-client-{{ ocp_release }}/openshift-client-linux-{{ ocp_release }}.tar.gz
+
+    - name: Create /usr/local/bin/oc and /usr/local/bin/openshift-install symbolic links
+      ignore_errors: yes
+      become: yes
+      file:
+        src: "{{ item.value }}"
+        dest: "{{ item.key }}"
+        state: link
+        force: yes
+      with_dict:
+        "/usr/local/bin/oc": "{{ ocp_install_path }}/artifacts/openshift-client-{{ ocp_release }}/oc"
+        "/usr/local/bin/openshift-install": "{{ ocp_install_path }}/artifacts/openshift-installer-{{ ocp_release }}/openshift-install"
+
     - name: Clone Openshift installer repo
       git:
         repo: "{{ ocp_openshift_installer_repo }}"
@@ -32,12 +58,25 @@
         clone: yes
         force: yes
 
+    ## NOTE : In order to reliably manage deployment we must use a matching repo for the release to be installed
+    - name: Find git commit ID for OCP release
+      shell: |
+        /usr/local/bin/oc adm release info {{ ocp_release }} --commit-urls \
+          |awk '{ if ( $1 == "installer" ) { n=split($2,a,"/"); print a[n]} }'
+      register:
+        installercommitid
+
+    - name: Checkout specific GIT commit ID for release {{ installercommitid.stdout }}
+      shell: >
+        git checkout {{ installercommitid.stdout }}
+      args:
+        chdir:
+          "{{ kvm_workdir }}/go/src/github.com/openshift/installer"
+
     ## NOTE: We need to modify manifests because of https://github.com/openshift/installer/issues/1007 otherwise the console won't come up
     - name: Change local_only to solve issue 1007
       shell: |
         sed -i "s/local_only = true/local_only = true\n    forwarders { \n        address = \"{{ kvm_libvirt_network_gw }}\"\n        domain = \"apps.\${var.cluster_domain}\" \n    }/g" {{ kvm_workdir }}/go/src/github.com/openshift/installer/data/data/libvirt/main.tf
-
-
 
     - name: Change timeouts to 180m
       shell: |
@@ -46,24 +85,13 @@
         sed -i 's/timeout := 30/timeout := 180/g' {{ kvm_workdir }}/go/src/github.com/openshift/installer/cmd/openshift-install/create.go
         sed -i 's/consoleRouteTimeout := 10/consoleRouteTimeout := 60/g' {{ kvm_workdir }}/go/src/github.com/openshift/installer/cmd/openshift-install/create.go
 
-## NOT NEEDED ANYMORE, libvirt_master_size variable was added
-##
-#    - name: FIX master disk in code (Right now there is no other way)
-#      shell: |
-#        SIZE=$(({{ ocp_master_disk }}*1073741824))
-#        sed -i "s/resource \"libvirt_volume\" \"master\" {/resource \"libvirt_volume\" \"master\" {\n  size           = ${SIZE}/g" {{ kvm_workdir }}/go/src/github.com/openshift/installer/data/data/libvirt/main.tf
-
-
     - name: Build the Openshift installer with libvirt support
       shell: |
         cd {{ kvm_workdir }}/go/src/github.com/openshift/installer/
         TAGS=libvirt hack/build.sh
 
 ################
-
-
-################
-
+# Preparation tasks
 
 - name: Prepare OpenShift installation
   when: ocp_prepare == "true"
@@ -99,14 +127,6 @@
     - name: Download Openshift installer
       shell: "cp {{ kvm_workdir }}/go/src/github.com/openshift/installer/bin/openshift-install {{ ocp_install_path }}/artifacts/openshift-installer-{{ ocp_release }}/"
 
-
-### Using shell with curl and tar instead of unarchive to avoid "Request failed: <urlopen error _ssl.c:880: The handshake operation timed out>" problem
-#    - name: Download Openshift client
-#      unarchive:
-#        src: "{{ ocp_mirror }}/{{ ocp_release }}/openshift-client-linux-{{ ocp_release }}.tar.gz"
-#        dest: "{{ ocp_install_path }}/artifacts/openshift-client-{{ ocp_release }}/"
-#        remote_src: yes
-#        creates: "{{ ocp_install_path }}/artifacts/openshift-client-{{ ocp_release }}/oc"
     - name: Download Openshift client
       shell: |
         curl --compressed -J -L -o {{ ocp_install_path }}/artifacts/openshift-client-{{ ocp_release }}/openshift-client-linux-{{ ocp_release }}.tar.gz  {{ ocp_mirror }}/{{ ocp_release }}/openshift-client-linux-{{ ocp_release }}.tar.gz
@@ -136,15 +156,8 @@
         dest: "{{ ocp_install_path }}/install/install-config.yaml"
         owner: "{{ ansible_user}}"
 
-############ Run installation
-
-### There is an issue.
-#The underlying issue is known #2632
-#registry.svc.ci.openshift.org/origin/release:4.3 release image has OKD content and needs to be installed using the installer from https://github.com/openshift/okd
-#Therefore any installs of OCP using master/ other release braches requires the user override the release image to OCP one.
-
-# So we need to override the release image: https://access.redhat.com/solutions/3880221
-
+############
+# Run installation
 
 - name: Install OpenShift
   when: ocp_install == "true"
@@ -175,51 +188,26 @@
         {{ ocp_install_path }}/install/openshift/99_openshift-cluster-api_worker-machineset-0.yaml
 
 
-#    ## NOTE: We need to modify manifests because of https://github.com/openshift/installer/issues/1007 otherwise the console won't come up
-#    - name:  Configure manifests to solve issue 1007
-#      shell: |
-#        sed -i 's/{{ metadata.name }}.//' {{ ocp_install_path }}/install/manifests/cluster-ingress-02-config.yml
+    - name: No Workers configuration
+      when: compute.0.replicas == 0
+      block:
+        - name:  Configure manifests to support no worker nodes
+          shell: |
+            sed -i 's/mastersSchedulable: false/mastersSchedulable: true/' {{ ocp_install_path }}/install//manifests/cluster-scheduler-02-config.yml
 
-
-#    - name: Single Master configuration
-#      when: controlPlane.replicas == 1
-#      block:
-#        - name:  Configure ETCD to support single master
-#          blockinfile:
-#            path: "{{ ocp_install_path }}/install/manifests/cvo-overrides.yaml"
-#            block: |
-#              #
-#                overrides:
-#                - group: apps/v1
-#                  kind: Deployment
-#                  name: etcd-quorum-guard
-#                  namespace: openshift-machine-config-operator
-#                  unmanaged: true
-
-
-#    - name: No Workers configuration
-#      when: compute.0.replicas == 0
-#      block:
-#        - name:  Configure manifests to support no worker nodes
-#          shell: |
-#            sed -i 's/mastersSchedulable: false/mastersSchedulable: true/' {{ ocp_install_path }}/install//manifests/cluster-scheduler-02-config.yml
-
-
-############# BUG https://bugzilla.redhat.com/show_bug.cgi?id=1805034
+    ############# BUG https://bugzilla.redhat.com/show_bug.cgi?id=1805034
     - name: Copy patch for bug 1805034
       when: controlPlane.replicas == 1
       copy:
         src: "single-master-patch.sh"
         dest: "{{ ocp_install_path }}/single-master-patch.sh"
         mode: '0775'
-#############
+
     - name: Display message about impending OpenShift install
       debug:
         msg: "The next task - OpenShift Install - might take some time to produce any output, please be patient. Thank you."
 
     - name: OpenShift install
-    #  shell: "{{ ocp_install_path }}/artifacts/openshift-installer-{{ ocp_release }}/openshift-install create cluster --dir {{ ocp_install_path }}/install/"
-    # With overrides
       shell: |
         ############# BUG https://bugzilla.redhat.com/show_bug.cgi?id=1805034
         if [ {{ controlPlane.replicas }} -eq 1 ]
@@ -232,6 +220,8 @@
         export GOCACHE={{ kvm_workdir }}/go-build
         {{ ocp_install_path }}/artifacts/openshift-installer-{{ ocp_release }}/openshift-install create cluster --dir {{ ocp_install_path }}/install/
 
+############
+# Post installation
 
 - name: OpenShift Post-Install
   when: ocp_install == "true"
@@ -247,7 +237,6 @@
     - name: Copy kubeconfig for admin
       shell: "mkdir ~/.kube ; cp {{ ocp_install_path }}/install/auth/kubeconfig ~/.kube/config "
 
-
     - name: Trust locally Ingress default CA
       shell: |
         while [[ $(oc -n openshift-ingress get secret/router-certs-default | grep router-certs-default  > /dev/null ; echo $?) != "0" ]]; do echo "Waiting for router-certs-default object" && sleep 10; done
@@ -257,13 +246,8 @@
         sudo chmod 0644 /etc/pki/ca-trust/source/anchors/ingress-cacert.pem
         sudo update-ca-trust extract
 
-
     - name: Configure Autocompletion
       shell: "oc completion bash > oc_bash_completion   ;  sudo cp oc_bash_completion /etc/bash_completion.d/ ; yum install -y bash-completion"
-
-
-
-
 
     - name: Create post-installation directory
       file:
@@ -289,7 +273,6 @@
       shell: "cd {{ ocp_install_path }}/post-install/nfs-registry/  ; chmod +x run.sh ; ./run.sh "
       when: nfs_storage  == "true"
 
-
     - name: Configure Registry Storage (Ephemeral)
       shell: |
         oc patch configs.imageregistry.operator.openshift.io cluster --type merge --patch '{"spec":{"storage":{"emptyDir":{}}}}'
@@ -303,9 +286,6 @@
       shell: "export CLUSTERADMIN_PASSWORD='{{ ocp_clusteradmin_password }}' ; export USERS_PASSWORD='{{ ocp_users_password }}'; cd {{ ocp_install_path }}/post-install/authentication/  ; chmod +x run.sh ; ./run.sh "
       when: ocp_create_users  == "true"
 
-
-
-
     - name: Enable VM auto-start
       become: true
       ignore_errors: yes
@@ -315,7 +295,6 @@
         do
           virsh autostart $i
         done
-
 
     - name: Persist dhcp host entries across reboots
       become: true

--- a/tasks/ocp_deploy.yml
+++ b/tasks/ocp_deploy.yml
@@ -56,7 +56,7 @@
 
     - name: Checkout specific GIT commit ID for release {{ installercommitid.stdout }}
       shell: |
-        git checkout -b release-{{ ocp_release }} {{ installercommitid.stdout }}
+        git checkout -b release-{{ ocp_release }} {{ installercommitid.stdout }} || /bin/true
       args:
         chdir:
           "{{ kvm_workdir }}/go/src/github.com/openshift/installer"


### PR DESCRIPTION
This is related to this:
https://github.com/openshift/installer/issues/4332
Some changes introduced in master before 4.5.16 became incompatible with previous versions.
Since the role was checking out 'master' instead of the proper commit, it left us unable to deploy 4.5 until the matching
changes merged into the installer (4.5.18).
For me, it meant that 4.5 deploys were broken for almost 10 days.
After some research, guidance came from the developers: checkout the proper commit version for the version you're trying to install.
I finally managed to fix it in my tree tonight (using the oc command to spit out the proper commit URL).
Please let me know what you think @luisarizmendi @kenmoini 
Thanks,
Vincent